### PR TITLE
Point source temp fix

### DIFF
--- a/gfail/webpage.py
+++ b/gfail/webpage.py
@@ -823,7 +823,10 @@ def create_info(event_dir, lsmodels=None, lqmodels=None):
     base_url = 'https://earthquake.usgs.gov/earthquakes/eventpage/'
 
     # Is this a point source?
-    point = is_grid_point_source(shake_grid)
+    # point = is_grid_point_source(shake_grid)
+    # Temporarily hard code this until we can get a better solution via
+    # new grid.xml attributes.
+    point = True
 
     try:
         # Hopefully this will eventually be more reliable once we get the


### PR DESCRIPTION
This just hard codes the point source warning to be True for now. This is a very short term fix so that, at a minimum, the groundfailure product will run. I will update this to use new grid.xml header info once it is available. 