### PR TITLE
Updates to gfail and gfail_transfer

### DIFF
--- a/bin/gfail
+++ b/bin/gfail
@@ -5,6 +5,9 @@
 import argparse
 from configobj import ConfigObj
 import os
+import sys
+
+from mapio.shake import getHeaderData
 
 # local imports
 from gfail.gfailrun import run_gfail
@@ -109,14 +112,17 @@ if __name__ == '__main__':
         '-u', '--uncertfile', metavar='uncertfile', nargs='?',
         help='single ShakeMap uncertainty.xml file', default=None)
     parser.add_argument(
-        '-tr', '--trimfile', metavar='trimocean', nargs='?', default=trimfile,
+        '-tr', '--trimfile', metavar='trimocean', nargs='?',
+        default=trimfile,
         help=('Location of shapefile of land masses to use to trim areas '
               'over water'))
     parser.add_argument(
-        '-pdl', '--pdl-config', metavar='pdlconfig', nargs='?', default=pdl_config,
+        '-pdl', '--pdl-config', metavar='pdlconfig', nargs='?',
+        default=pdl_config,
         help=('Location of config file for pdl (optional)'))
     parser.add_argument(
-        '-log', '--log-filepath', metavar='logfilepath', nargs='?', default=log_filepath,
+        '-log', '--log-filepath', metavar='logfilepath', nargs='?',
+        default=log_filepath,
         help=('Location of log filepath'))
     parser.add_argument(
         '-db', '--dbfile', metavar='dbfile', nargs='?', default=dbfile,
@@ -176,14 +182,40 @@ if __name__ == '__main__':
         help='Clears all existing default paths')
     parser.add_argument(
         '-w', '--make-webpage', action='store_true', default=False,
-        help='Create all files needed for product page creation and compute alerts')
+        help='Create all files needed for product page creation and compute '
+             'alerts')
     parser.add_argument(
         '-ext', '--extract-contents', action='store_true', default=False,
-        help='All files will be placed directly in output folder, will not be nested '
-             'in a subfolder named by eventid')
+        help='All files will be placed directly in output folder, will not be '
+             'nested in a subfolder named by eventid')
     parser.add_argument("--property-alertlevel", default='unset')
-    parser.add_argument("--eventsource", help='Comcat eventsource.')
-    parser.add_argument("--eventsourcecode", help='Comcat eventsourcecode.')
+    parser.add_argument(
+        "--eventsource",
+        help='Comcat eventsource.',
+        default="")
+    parser.add_argument(
+        "--eventsourcecode",
+        help='Comcat eventsourcecode.',
+        default="")
 
     pargs = parser.parse_args()
+
+    codes_set = (pargs.eventsource == "") or (pargs.eventsourcecode == "")
+    if codes_set and pargs.shakefile:
+        shake_tuple = getHeaderData(pargs.shakefile)
+        eid = shake_tuple[1]['event_id']
+
+        if not len(eid):
+            eid = shake_tuple[0]['event_id']
+        network = shake_tuple[1]['event_network']
+
+        if network == '':
+            network = 'us'
+
+        if eid.startswith(network):
+            eid = eid[len(network):]
+
+        pargs.eventsource = network
+        pargs.eventsourcecode = eid
+
     run_gfail(pargs)

--- a/bin/gfail_transfer
+++ b/bin/gfail_transfer
@@ -18,7 +18,7 @@ def main(event_dir, pdl_conf, dry_run):
         dry_run (bool): Dry run means do not transfer.
     """
 
-    success = gf_transfer(event_dir, pdl_conf, dry_run)
+    success = gf_transfer(event_dir, pdl_config=pdl_conf, dry_run=dry_run)
 
 
 if __name__ == '__main__':

--- a/gfail/transfer.py
+++ b/gfail/transfer.py
@@ -1,7 +1,7 @@
 import gfail.pdl as pdl
 
 
-def gf_transfer(event_dir, version, pdl_config=None, dry_run=False,
+def gf_transfer(event_dir, version=1, pdl_config=None, dry_run=False,
                 status='UPDATE'):
     """
     Transfer ground failure results to dev server.


### PR DESCRIPTION
These are updates to try to get `gfail` to work as reliably as possible with recent changes. One key thing is that we have added the product "version" which is largely managed inside `callgf` and so I don't think it makes sense to have `gfail` do this also, so currently the version is pretty much hard coded to be 1 when run by `gfail`. By and large I think that the `gfail` workflow will succeed with new events when the eventid is correctly specified in the grid.xml header, but this is not reliable particularly for Atlas events. 