### PR TITLE
Added flexibility to callgf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: false
 
+services:
+    - xvfb
 install:
     # Install gf and requirements
     - bash install.sh -r
@@ -10,11 +12,6 @@ install:
     - pwd
     - cp .gfail_defaults_travis /home/travis/.gfail_defaults
     - conda list
-before_script:
-    # This is to take care of Invalid DISPLAY variable
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-    - sleep 3 # give xvfb some time to start
 script:
     - export PYTHONPATH="."
     - py.test --cov=.

--- a/bin/callgf
+++ b/bin/callgf
@@ -39,7 +39,7 @@ from impactutils.time.ancient_time import HistoricTime as ShakeDateTime
 import pytz
 
 # local imports
-from gfail.gfailrun import run_gfail
+from gfail.gfailrun import run_gfail, isURL, getGridURL
 from gfail.transfer import gf_transfer
 
 
@@ -283,6 +283,7 @@ def get_event_dir(args, connection):
     shakemap_version = 0
 
     eventids = args.eventids.split(',')
+
     for eventid in eventids:
         with connection:
             cursor = connection.cursor()
@@ -291,6 +292,8 @@ def get_event_dir(args, connection):
                 (eventid,))
             rows = cursor.fetchall()
         if rows is None:
+            continue
+        if len(rows) == 0:
             continue
         # Get most recent entry
         try:
@@ -446,6 +449,13 @@ def stop_unstop(args, config):
         args.eventids = args.stop
     elif args.unstop:
         args.eventids = args.unstop
+
+    try: # # Get all event ids for this event
+        detail = get_event_by_id(args.eventids)
+        eventids = ','.join(detail['ids'][1:].split(','))
+        args.eventids = eventids
+    except Exception as e:
+        logging.info('Unable to find additional event ids for this event, continuing with just one provided')
 
     dbfile = config['dbfile']
     conn = connect_database(dbfile)
@@ -609,7 +619,6 @@ def process_shakemap(args, config):
 
         # Get the directory for this new version
         vdir, version, eventdir = get_version_dir(eventid, eventdir, config)
-
         # insert what we know about the event into the database
         db_id = insert_event(conn, eventid, args, version)
         logging.info('Inserted event placeholder into database')
@@ -1018,10 +1027,34 @@ def main(args, config):
         datadir = os.path.join(tdir, 'download')
         os.mkdir(datadir)
         try:
-            detail = get_event_by_id(args.event)
             fname = os.path.join(datadir, 'grid.xml')
-            shakemap = detail.getProducts('shakemap')[0]
-            shakemap.getContent('grid.xml', fname)
+            # If args.event is a url to a shakemap, download from that url
+            if isURL(args.event):
+                try:
+                    shakefile = getGridURL(args.event, fname)
+                except Exception as e:
+                    msg = 'Could not download shakemap file from provided URL: %s'
+                    logging.exception(msg % (e))
+                    sys.exit(1)
+
+                args.event = getHeaderData(shakefile)[0]['event_id']
+                try:
+                    detail = get_event_by_id(args.event)
+                except:  # Maybe originator is missing from event id, try another way
+                    try:
+                        temp = getHeaderData(shakefile)[0]
+                        temp2 = '%s%s' % (temp['shakemap_originator'], temp['shakemap_id'])
+                        detail = get_event_by_id(temp2)
+                        args.event = temp2
+                    except Exception as e:
+                        msg = 'Could not get event detail for shakemap at provided URL: %s'
+                        logging.exception(msg % e)
+                        sys.exit(1)
+            else:
+                detail = get_event_by_id(args.event)
+                shakemap = detail.getProducts('shakemap')[0]
+                shakemap.getContent('grid.xml', fname)
+
             targs = ArgWrapper()
             targs.time = detail.time
             targs.preferred_eventsource = detail['net']

--- a/bin/callgf
+++ b/bin/callgf
@@ -24,7 +24,6 @@ from io import StringIO
 # third party imports
 # from impactutils.io.cmd import get_command_output
 from libcomcat.search import get_event_by_id
-from libcomcat.classes import VersionOption
 from impactutils.comcat.query import GeoServe
 from mapio.shake import getHeaderData
 from mapio.shake import ShakeGrid
@@ -631,7 +630,7 @@ def process_shakemap(args, config):
         try:
             detail = get_event_by_id(eventid, includesuperseded=True)
             allversions = detail.getProducts(
-                'shakemap', version=VersionOption.ALL)
+                'shakemap', version='all')
             vers = [allv.version for allv in allversions]
             idx = np.where(np.array(vers) == np.max(vers))[0][0]
             shakemap = allversions[idx]

--- a/bin/callgf
+++ b/bin/callgf
@@ -286,12 +286,20 @@ def get_event_dir(args, connection):
         with connection:
             cursor = connection.cursor()
             cursor.execute(
-                'SELECT id, eventdir FROM shakemap WHERE eventcode=?',
+                'SELECT id, eventdir, endtime FROM shakemap WHERE eventcode=?',
                 (eventid,))
-            row = cursor.fetchone()
-        if row is None:
+            rows = cursor.fetchall()
+        if rows is None:
             continue
-        id1, eventdir = row
+        # Get most recent entry
+        try:
+            indx = np.argmax([datetime.strptime(row[2], TIMEFMT) for row in rows])
+            id1, eventdir, date = rows[indx]
+        except: # Take any entries where eventdir is not empty
+            for row in rows:
+                id1, eventdir, date = row
+                if eventdir is not None and eventdir != '':
+                    continue
 
         if eventdir == '':
             eventdir = None
@@ -387,6 +395,7 @@ def cleanup_database(connection, config):
 
     Args:
         connection (sqlite connection): connection object.
+        config 
     """
     with connection:
         cursor = connection.cursor()
@@ -414,6 +423,62 @@ def cleanup_database(connection, config):
             files = glob.glob(os.path.join(entry.path, '*'))
             if len(files) == 0:
                 shutil.rmtree(entry.path)
+
+
+def stop_unstop(args, config):
+    """If args.stop is an eventid, put a "stop" file in the event folder
+        (will prevent future versions from being created until the file is removed.)
+        if args.unstop is an eventid, remove an existing stopfile to allow new
+        versions to be created
+        If this code is called, callgf will exit after
+        
+    Args:
+        args (arparser Namespace): Input arguments to callgf containing event id
+        config (ConfigObj): Configuration object containing database file location
+
+    """
+    # Connect to database, which keeps track of folders
+    if args.stop and args.unstop:
+        logging.exception('Both stop and unstop were set to True in args, impossible to do both')
+        sys.exit(1)
+    if args.stop:
+        args.eventids = args.stop
+    elif args.unstop:
+        args.eventids = args.unstop
+
+    dbfile = config['dbfile']
+    conn = connect_database(dbfile)
+    eventdir, shakemap_version = get_event_dir(args, conn)
+    if eventdir is None:
+        msg = 'No directory found for eventid %s. Stopping or unstopping was not completed.' % args.eventids
+        logging.exception(msg)
+        sys.exit(1)
+    
+    stopfile = os.path.join(eventdir, 'stop')
+
+    if args.stop:
+        if os.path.isfile(stopfile):
+            msg = 'Stop file already exists for %s: %s' % (args.eventids, stopfile)
+            logging.info(msg)
+            sys.exit(1)
+        else:
+            f = open(stopfile, 'wt')
+            f.write('Stopped: %s UTC' %
+                    datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'))
+            f.close()
+            msg = 'Stopfile added for %s: %s' % (args.eventids, stopfile)
+            logging.info(msg)
+            sys.exit(0)
+    elif args.unstop:
+        if not os.path.isfile(stopfile):
+            msg = 'No stop file exists to remove for %s in %s' % (args.eventids, eventdir)
+            logging.info(msg)
+            sys.exit(1)
+        else:
+            os.remove(stopfile)
+            msg = 'Stopfile removed for %s from %s' % (args.eventids, eventdir)
+            logging.info(msg)
+            sys.exit(0)
 
 
 def process_shakemap(args, config):
@@ -501,15 +566,18 @@ def process_shakemap(args, config):
 
         # get the database ID and directory of the event we have
         eventdir, shakemap_version = get_event_dir(args, conn)
-        
+
         # check for a stopfile
         if eventdir is not None:
             stopfile = os.path.join(eventdir, 'stop')
             if os.path.isfile(stopfile):
-                fmt = '"stop" file found in %s.  Stopping processing.'
-                logging.info(fmt % (eventdir))
                 if not args.force:
+                    fmt = '"stop" file found in %s.  Stopping processing.'
+                    logging.info(fmt % (eventdir))
                     sys.exit(1)
+                else:
+                    fmt = '"stop" file found in %s, but continuing because force flag was set.'
+                    logging.info(fmt % (eventdir))
 
         # get the event ID for this event
         eventsource = args.preferred_eventsource
@@ -913,11 +981,15 @@ def main(args, config):
     logging.config.dictConfig(log_cfg)
     logger = logging.getLogger()
     logging.info('---------------------------------------------------------')
+
+    # Check if this is just a stop or unstop (won't pass beyond these lines if so)
+    if args.stop or args.unstop:
+        stop_unstop(args, config)
+
     logging.info('Running process_shakemap')
 
     if args.event is not 'unset':
         # For manual run, event is set (default is 'unset')
-
         # download the shakemap to a temporary directory
         tdir = tempfile.mkdtemp()
         datadir = os.path.join(tdir, 'download')
@@ -1058,6 +1130,21 @@ the data_path directory.
         help="Check database for events that need to be resent to remove "
              "the warning banner. If set, nothing else happens and no other "
              "flags matter.")
+    argparser.add_argument(
+        "--stop",
+        default=False, metavar='EVENTID',
+        help="Add stopfile to directory for this event to stop event EVENTID "
+             "from being rerun automatically if ShakeMap is updated. No events "
+             "will be run with this command "
+             "Example: callgf --stop us1000abcd")
+    argparser.add_argument(
+        "--unstop",
+        default=False, metavar='EVENTID',
+        help="Remove stopfile from directory for this event to allow event EVENTID "
+             "to be rerun automatically again if ShakeMap is updated. No events "
+             "will be run with this command "
+             "Example: callgf --unstop us1000abcd")
+            
 
     # argparser.add_argument("--rerun", action='store_true', default=False,
     #                       help="Rerun an event that is already in the database. "

--- a/bin/callgf
+++ b/bin/callgf
@@ -501,6 +501,15 @@ def process_shakemap(args, config):
 
         # get the database ID and directory of the event we have
         eventdir, shakemap_version = get_event_dir(args, conn)
+        
+        # check for a stopfile
+        if eventdir is not None:
+            stopfile = os.path.join(eventdir, 'stop')
+            if os.path.isfile(stopfile):
+                fmt = '"stop" file found in %s.  Stopping processing.'
+                logging.info(fmt % (eventdir))
+                if not args.force:
+                    sys.exit(1)
 
         # get the event ID for this event
         eventsource = args.preferred_eventsource
@@ -983,7 +992,7 @@ the data_path directory.
         help="Directory where ShakeMap data can be found",
         metavar='DIRECTORY')
     argparser.add_argument(
-        "--event",
+        "-e", "--event",
         default='unset',
         help="Event ID of event to run manually",
         metavar='EVENTID')

--- a/bin/callgf
+++ b/bin/callgf
@@ -1010,8 +1010,14 @@ def main(args, config):
         del log_cfg['handlers']['default']['when']
     else:
         log_cfg['handlers']['default']['filename'] = logfile
+
     logging.config.dictConfig(log_cfg)
     logger = logging.getLogger()
+    # Print to screen if manual run
+    if args.event != 'unset' or args.stop or args.unstop:
+        # Change logging to also output to screen
+        ch = logging.StreamHandler(sys.stdout)
+        logger.addHandler(ch)
     logging.info('---------------------------------------------------------')
 
     # Check if this is just a stop or unstop (won't pass beyond these lines if so)

--- a/bin/callgf
+++ b/bin/callgf
@@ -32,9 +32,6 @@ import configobj
 import fiona
 from shapely.geometry import shape, box, Polygon, Point
 # from mpl_toolkits.basemap import Basemap
-import numpy as np
-from shapely.geometry import shape, box
-from libcomcat.search import get_event_by_id
 from impactutils.time.ancient_time import HistoricTime as ShakeDateTime
 import pytz
 

--- a/bin/callgf
+++ b/bin/callgf
@@ -281,6 +281,7 @@ def get_event_dir(args, connection):
     # database to see if we have processed this event before.
     eventdir = None
     shakemap_version = 0
+
     eventids = args.eventids.split(',')
     for eventid in eventids:
         with connection:
@@ -481,6 +482,40 @@ def stop_unstop(args, config):
             sys.exit(0)
 
 
+def isstopped(args, config):
+    """
+    Quickly check if event id is stopped, stop code if it does exist
+
+    Args:
+        args (arparser Namespace): Input arguments to callgf containing event id
+        config (ConfigObj): Configuration object containing database file location
+
+    Returns:
+        tuple containing:
+            -True if stopfile is found in directory for eventid, False if not found
+            -event directory in which file was found (None if not found)
+    """
+    dbfile = config['dbfile']
+    conn = connect_database(dbfile)
+    eventdir, shakemap_version = get_event_dir(args, conn)
+    if eventdir is None:
+        stopstat = False
+    else:
+        stopfile = os.path.join(eventdir, 'stop')
+        if os.path.isfile(stopfile):
+            stopstat = True
+        else:
+            stopstat = False
+    if stopstat:
+        if not args.force:
+            fmt = '"stop" file found in %s.  Stopping processing.'
+            logging.info(fmt % (eventdir))
+            sys.exit(1)
+        else:
+            fmt = '"stop" file found in %s, but continuing because force flag was set.'
+            logging.info(fmt % (eventdir))
+
+
 def process_shakemap(args, config):
     """Process the ShakeMap.
 
@@ -566,18 +601,6 @@ def process_shakemap(args, config):
 
         # get the database ID and directory of the event we have
         eventdir, shakemap_version = get_event_dir(args, conn)
-
-        # check for a stopfile
-        if eventdir is not None:
-            stopfile = os.path.join(eventdir, 'stop')
-            if os.path.isfile(stopfile):
-                if not args.force:
-                    fmt = '"stop" file found in %s.  Stopping processing.'
-                    logging.info(fmt % (eventdir))
-                    sys.exit(1)
-                else:
-                    fmt = '"stop" file found in %s, but continuing because force flag was set.'
-                    logging.info(fmt % (eventdir))
 
         # get the event ID for this event
         eventsource = args.preferred_eventsource
@@ -988,7 +1011,7 @@ def main(args, config):
 
     logging.info('Running process_shakemap')
 
-    if args.event is not 'unset':
+    if args.event != 'unset':
         # For manual run, event is set (default is 'unset')
         # download the shakemap to a temporary directory
         tdir = tempfile.mkdtemp()
@@ -1022,6 +1045,8 @@ def main(args, config):
                 else:
                     targs.property_alertlevel = 'unset'
             targs.eventids = ','.join(detail['ids'][1:].split(','))
+            # Check if stopfile exists before proceeding
+            isstopped(targs, config)
             process_shakemap(targs, config)
         except Exception as e:
             print('Processing failed on %s. "%s"' % (args.event, str(e)))
@@ -1030,6 +1055,8 @@ def main(args, config):
     else:
         # Called by pdl
         if args.type == 'losspager':
+            # Check if stopfile exists before proceeding
+            isstopped(args, config)
             process_shakemap(args, config)
         else:
             logging.info('Incorrect type specified, exiting.')
@@ -1135,7 +1162,7 @@ the data_path directory.
         default=False, metavar='EVENTID',
         help="Add stopfile to directory for this event to stop event EVENTID "
              "from being rerun automatically if ShakeMap is updated. No events "
-             "will be run with this command "
+             "will be run with this command. Overidden by -f flag "
              "Example: callgf --stop us1000abcd")
     argparser.add_argument(
         "--unstop",

--- a/bin/gfail_transfer
+++ b/bin/gfail_transfer
@@ -8,7 +8,7 @@ import argparse
 from gfail.transfer import gf_transfer
 
 
-def main(event_dir, pdl_conf, dry_run):
+def main(event_dir, pdl_conf, dry_run, version):
     """
     Transfer results to comcat.
 
@@ -16,9 +16,10 @@ def main(event_dir, pdl_conf, dry_run):
         event_dir (srt): Directory containing ground failure results.
         pdl_conf (str): Path to PDL config file.
         dry_run (bool): Dry run means do not transfer.
+        version (int): version of event being sent
     """
 
-    success = gf_transfer(event_dir, pdl_config=pdl_conf, dry_run=dry_run)
+    success = gf_transfer(event_dir, version=version, pdl_config=pdl_conf, dry_run=dry_run)
 
 
 if __name__ == '__main__':
@@ -37,5 +38,8 @@ if __name__ == '__main__':
                         action='store_true', default=False,
                         help='Do not actually call the PDL command.',
                         required=False)
+    parser.add_argument('-v', '--version',
+                        help='Manually set version number',
+                        required=False, default=1)
     args = parser.parse_args()
-    main(args.event_dir, args.config, args.dryrun)
+    main(args.event_dir, args.config, args.dryrun, args.version)

--- a/gfail/gfailrun.py
+++ b/gfail/gfailrun.py
@@ -443,10 +443,11 @@ def run_gfail(args):
         return filenames
 
 
-def getGridURL(gridurl):
+def getGridURL(gridurl, fname=None):
     """
     Args:
         gridurl (str): url for Shakemap grid.xml file.
+        fname (str): file location name, if None, will create a temporary file
 
     Returns:
         file object corresponding to the url.
@@ -456,8 +457,12 @@ def getGridURL(gridurl):
     fh = None
     with urllib.request.urlopen(gridurl) as fh:
         data = fh.read().decode('utf-8')
-        with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
-            f.write(data)
+        if fname is None:
+            with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
+                f.write(data)
+        else:
+            with open(fname, 'w') as f:
+                f.write(data)
 
     return f.name
 

--- a/gfail/stats.py
+++ b/gfail/stats.py
@@ -65,9 +65,9 @@ def computeStats(grid2D, probthresh=None, shakefile=None,
 
     if len(grid) == 0:
         print('no probability values above statprobthresh')
-        stats['Max'] = float('nan')
-        stats['Median'] = float('nan')
-        stats['Std'] = float('nan')
+        stats['Max'] = 0. #float('nan')
+        stats['Median'] = 0. #float('nan')
+        stats['Std'] = 0. #float('nan')
     else:
         stats['Max'] = float(np.nanmax(grid))
         stats['Median'] = float(np.nanmedian(grid))

--- a/gfail/transfer.py
+++ b/gfail/transfer.py
@@ -8,9 +8,9 @@ def gf_transfer(event_dir, version=1, pdl_config=None, dry_run=False,
 
     Args:
         event_dir (str): Path to event directory.
-        version (int): Version number of ground-failure run.
+        version (int): Version number to assign to ground-failure run.
         pdl_config (str): Path to PDL config file.
-        dry_run (bool): True suppresss transfer but data is assesmbled for
+        dry_run (bool): True suppresses transfer but data is assembled for
             the transfer.
         status (str): Status of ground-failure product being sent to comcat.
             Default is "UPDATE" but can also be "WARNING" so that the product

--- a/gfail/utilities.py
+++ b/gfail/utilities.py
@@ -10,7 +10,6 @@ import collections
 # local imports
 from mapio.shake import getHeaderData
 from libcomcat.search import get_event_by_id, search
-from libcomcat.classes import VersionOption
 from mapio.basemapcity import BasemapCities
 from mapio.multihaz import MultiHazardGrid
 
@@ -98,7 +97,7 @@ def get_event_comcat(shakefile, timewindow=60, degwindow=0.3, magwindow=0.2):
         if not len(events):
             return None
         detail = events[0].getDetailEvent()
-    allversions = detail.getProducts('shakemap', version=VersionOption.ALL)
+    allversions = detail.getProducts('shakemap', version='all')
     # Find the right version
     vers = [allv.version for allv in allversions]
     idx = np.where(np.array(vers) == version)[0][0]

--- a/gfail/webpage.py
+++ b/gfail/webpage.py
@@ -707,7 +707,7 @@ def create_info(event_dir, lsmodels=None, lqmodels=None,
         # constructed on the website and so we don't need them here)
         ls_haz_alert, ls_pop_alert, lq_haz_alert, lq_pop_alert, \
             ls_alert, lq_alert = alert_info
-
+            
         if lsmodels is None:
             lsmodels = [{
                 'id': 'nowicki_jessee_2017',
@@ -881,7 +881,7 @@ def create_info(event_dir, lsmodels=None, lqmodels=None,
 
     info_file = os.path.join(event_dir, 'info.json')
     with open(info_file, 'w') as f:
-        json.dump(info_dict, f)
+        json.dump(info_dict, f, allow_nan=False)
     filenames.append(info_file)
     return filenames
 

--- a/gfail/webpage.py
+++ b/gfail/webpage.py
@@ -881,7 +881,7 @@ def create_info(event_dir, lsmodels=None, lqmodels=None,
 
     info_file = os.path.join(event_dir, 'info.json')
     with open(info_file, 'w') as f:
-        json.dump(info_dict, f, allow_nan=False)
+        json.dump(info_dict, f) # allow_nan=False)
     filenames.append(info_file)
     return filenames
 


### PR DESCRIPTION
- Added stopfile capability
- Now allows callgf to be called with a shakemap url (to allow the use of non-authoritative shakemaps when run manually)
- When callgf is run manually, the log entries (describing what is happening) now print to screen as well as to the logs
- fixed issue with NaN being added to info.json (which is invalid) by replacing NaNs with zero
- allowed capability to manually set version number