### PR TITLE
Deal with issues that occur when ShakeMap fails to download

### DIFF
--- a/bin/callgf
+++ b/bin/callgf
@@ -395,6 +395,8 @@ def insert_event(connection, eventid, args, version):
         time = 'unknown'
     else:
         time = args.time
+        if isinstance(time, str):
+            time = datetime.strptime(time, '%Y-%m-%dT%H:%M:%S.%fZ')
     if args.depth is None:
         depth = -999.
     else:
@@ -696,7 +698,7 @@ def process_shakemap(args, config):
         logging.critical('Database entry failed: %s' % e)
         logging.info('Continuing to run without database.')
         shakemap_version = 0
-
+        db_id = None
     # ----------------------------------------------------------------------
     # Download grid.xml and uncertfiles
     # ----------------------------------------------------------------------
@@ -712,6 +714,7 @@ def process_shakemap(args, config):
         max_attempts = 4
         sleep = 60.0  # seconds
         attempts = 0
+
         while attempts < max_attempts:
             try:
                 datadir = os.path.join(args.directory, 'download')
@@ -722,6 +725,7 @@ def process_shakemap(args, config):
                     getShakefiles(eventid, datadir, uncert=True,
                                   version=args.version,
                                   source=args.source)
+                break
 
             except Exception as e:
                 logging.info(
@@ -749,7 +753,8 @@ def process_shakemap(args, config):
                % gridfile)
         logging.info(msg)
         # if not args.force:
-        update_event_fail(conn, db_id, msg)
+        if db_id is not None:
+            update_event_fail(conn, db_id, msg)
         sys.exit(1)
 
     logging.info('Checking for uncertainty gridfile...')

--- a/bin/callgf
+++ b/bin/callgf
@@ -661,7 +661,7 @@ def process_shakemap(args, config):
         if any_pass:
             logging.info('Magnitude check passed')
         else:
-            logging.info('Magnitude check failed')
+            logging.info('Magnitude below thresholds')
             if not args.force:
                 sys.exit(1)
             else:
@@ -828,7 +828,7 @@ def process_shakemap(args, config):
         logging.info(msg)
 
     if set_bounds is not None:
-        msg = ('Bounds adjusted to: %s' % set_bounds)
+        msg = ('Bounds adjusted to: %s. ' % set_bounds)
         logging.info(msg)
         note = msg
 
@@ -1028,9 +1028,10 @@ def process_shakemap(args, config):
     if not success:
         msg = "gf_transfer failed."
         logging.critical(msg)
-        update_event_fail(conn, db_id, msg)
+        #update_event_fail(conn, db_id, msg)
         # sys.exit(1)  # Still proceed because can enter stuff in database
         transferred = False
+        note += msg
     else:
         logging.info('gf_transfer completed')
         transferred = True
@@ -1138,7 +1139,7 @@ def cleanup(args, config):
 
     # Database
     dbfile = config['dbfile']
-    conn = connect_database(dbfile) 
+    conn = connect_database(dbfile)
     # Now rerun any events that haven't run in 2 days to reset warning flags
     # And rerun any events that didn't run because couldn't get ShakeMap
     # grid.xml due to network problems
@@ -1192,6 +1193,32 @@ def cleanup(args, config):
                 args.event = uevent[0]
                 args.force = True
                 main(args, config, exitafter=False)
+    
+    # Check if any didn't transfer and need to be resent
+    with conn:
+        cursor.execute("SELECT id, eventcode, note, eventdir, version FROM shakemap")
+        lines = cursor.fetchall()
+        for line in lines:
+            if 'gf_transfer failed.' in line:
+                pdl_conf = config['pdl_config']
+                id1, eid, note, eventdir, version = line
+                if eventdir is not None:
+                    fulldir = os.path.join(eventdir, 'version.%03i' % version)
+                    success = gf_transfer(fulldir, version=version,
+                                          pdl_config=pdl_conf,
+                                          dry_run=args.dry_run)
+                    logging.info('Attempting to resend %s. gfail_transfer '
+                                 'failed previously' % eid)
+                    if success:  # Update database entry
+                        msg = 'gf_transfer completed after retry at %s' % \
+                            datetime.now().strftime(TIMEFMT)
+                        logging.info(msg)
+                        logging.info('Updating database')
+                        cursor.execute(
+                            "UPDATE shakemap SET note = ? WHERE id = ?",
+                            (msg, id1))
+                    else:
+                        logging.info('gf_transfer failed again')
 
     logging.info('Finished running cleanup')
     logging.info('---------------------------------------------------------')

--- a/bin/callgf
+++ b/bin/callgf
@@ -1157,9 +1157,9 @@ def cleanup(args, config):
             # See if currently running, if started a long time ago, cleanup
             if 'Currently running...' in notelist:
                 idx = notelist.index('Currently running...')
-                # If has been currently running for more than 2 hrs, 
+                # If has been currently running for more than 40 mins, 
                 # probably failed and needs to be cleaned up
-                if datetime.now() - start_time_list[idx] > timedelta(hours=2):
+                if datetime.now() - start_time_list[idx] > timedelta(minutes=40):
                     cleanup_database(conn, config)
                     notelist.pop(idx)
                     start_time_list.pop(idx)

--- a/bin/callgf
+++ b/bin/callgf
@@ -399,9 +399,8 @@ def insert_event(connection, eventid, args, version):
         depth = -999.
     else:
         depth = args.depth
-
     tpl = (eventid, version,
-           args.latitude, args.longitude, time,
+           args.latitude, args.longitude, time.strftime(TIMEFMT),
            args.magnitude, tnowstr,
            'Currently running...', depth)
     list1 = []
@@ -1109,8 +1108,9 @@ class ArgWrapper():
     pass
 
 
-def cleanup_warnings(args, config):
-    """Function to cleaning up warnings.
+def cleanup(args, config):
+    """Function to clean up database and check if any events need to be rerun.
+    Should be run periodically using crontab, for example
 
     Args:
         args (arparser Namespace): Input arguments.
@@ -1129,36 +1129,70 @@ def cleanup_warnings(args, config):
     logging.config.dictConfig(log_cfg)
     logger = logging.getLogger()
     logging.info('---------------------------------------------------------')
-    logging.info('Running cleanup_warnings')
+    logging.info('Running cleanup')
 
     # Database
     dbfile = config['dbfile']
-    conn = connect_database(dbfile)
+    conn = connect_database(dbfile) 
+    # Now rerun any events that haven't run in 2 days to reset warning flags
+    # And rerun any events that didn't run because couldn't get ShakeMap
+    # grid.xml due to network problems
     with conn:
         cursor = conn.cursor()
         cursor.execute("SELECT DISTINCT eventcode FROM shakemap")
         unique_events = cursor.fetchall()
         for uevent in unique_events:
             cursor.execute(
-                "SELECT id, eventcode, time, starttime FROM shakemap "
-                "where eventcode='%s'" % uevent[0]
+                "SELECT id, eventcode, time, starttime, note "
+                "FROM shakemap where eventcode='%s'" % uevent[0]
             )
             lines = cursor.fetchall()
             start_time_list = []
+            notelist = []
             for line in lines:
-                cid, eventcode, time, starttime = line
+                cid, eventcode, time, starttime, note = line
+                notelist.append(note)
                 start_time_list.append(
                     datetime.strptime(starttime, TIMEFMT))
-            last_start_time = max(start_time_list)
-            origin_time = datetime.strptime(time, TIMEFMT)
+            # See if currently running, if started a long time ago, cleanup
+            if 'Currently running...' in notelist:
+                idx = notelist.index('Currently running...')
+                # If has been currently running for more than 2 hrs, 
+                # probably failed and needs to be cleaned up
+                if datetime.now() - start_time_list[idx] > timedelta(hours=2):
+                    cleanup_database(conn, config)
+                    notelist.pop(idx)
+                    start_time_list.pop(idx)
+                    logging.info('Removed stalled entry for %s' % uevent[0])
+            idx2 = np.argmax(start_time_list)
+            last_start_time = start_time_list[idx2]
+            try:
+                origin_time = datetime.strptime(time, TIMEFMT)
+            except:
+                origin_time = datetime.strptime(time, '%Y-%m-%dT%H:%M:%S.%fZ')
             delta_run = last_start_time - origin_time
-            delta_now = datetime.now() - origin_time
-            if ((delta_now > timedelta(days=2)) and
-                    (not delta_run > timedelta(days=2))):
-                process_shakemap(args, config)
+            delta_now = datetime.utcnow() - origin_time
+            A = 'Failed to download shakemap files' in notelist[idx2]
+            B = ((delta_now > timedelta(days=2)) and
+                    (not delta_run > timedelta(days=2))
+                    and ('over water' not in notelist[idx2]))
+            if A or B:
+                if A:
+                    logging.info('Missing ShakeMap for %s, rerunning' %
+                        uevent[0])
+                if B:
+                    logging.info('Rerunning %s to remove warning flags '
+                    'because sufficient time has elapsed' % uevent[0])
+                #import pdb; pdb.set_trace()
+                args.event = uevent[0]
+                args.force = True
+                main(args, config, exitafter=False)
+
+    logging.info('Finished running cleanup')
+    logging.info('---------------------------------------------------------')
 
 
-def main(args, config):
+def main(args, config, exitafter=True):
     """Main entry point method.
 
     Args:
@@ -1237,7 +1271,11 @@ def main(args, config):
             isstopped(targs, config)
             process_shakemap(targs, config)
         except Exception as e:
-            print('Processing failed on %s. "%s"' % (args.event, str(e)))
+            msg = 'Processing failed on %s. "%s"' % (args.event, str(e))
+            logging.critical(msg)
+            print(msg)
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            logging.critical(traceback.format_exc())
         finally:
             shutil.rmtree(tdir)
     else:
@@ -1249,7 +1287,8 @@ def main(args, config):
         else:
             logging.info('Incorrect type specified, exiting.')
 
-    sys.exit(0)
+    if exitafter:
+        sys.exit(0)
 
 
 if __name__ == '__main__':
@@ -1347,10 +1386,12 @@ the data_path directory.
         help="PAGER alert level. If pending then override ground-failure "
              "alert levels to be pending.")
     argparser.add_argument(
-        "-c", "--cleanup-warnings",
+        "-c", "--cleanup",
         action='store_true', default=False,
-        help="Check database for events that need to be resent to remove "
-             "the warning banner. If set, nothing else happens and no other "
+        help="Clean stalled runs from database, check database for events that" 
+             " need to be rerun to remove the warning banner or if the"
+             "ShakeMap wasn't downloaded successfully. If set, nothing else "
+             "happens and no other "
              "flags matter.")
     argparser.add_argument(
         "--stop",
@@ -1385,7 +1426,7 @@ the data_path directory.
             print('\t%s' % req)
         sys.exit(1)
 
-    if pargs.cleanup_warnings:
-        cleanup_warnings(pargs, pconfig)
+    if pargs.cleanup:
+        cleanup(pargs, pconfig)
     else:
         main(pargs, pconfig)

--- a/bin/cleandb
+++ b/bin/cleandb
@@ -6,6 +6,7 @@ import argparse
 from configobj import ConfigObj
 import os
 import sqlite3 as lite
+import glob
 
 
 
@@ -13,17 +14,18 @@ if __name__ == '__main__':
     """
     Manually remove any "Currently running..." entries from the database
     """
-    # See if there is a default path file, load in if there is and
-    # replace any nones
+    # Get config file   
     defaults = os.path.join(os.path.expanduser('~'), '.gfail_defaults')
     dbfile = None
     alerttype = 'value'
 
     if os.path.exists(defaults):
-        D = ConfigObj(defaults)
-        for key in D:
+        pconfig = ConfigObj(defaults)
+        for key in pconfig:
             if key == 'dbfile':
-                dbfile = D[key]
+                dbfile = pconfig[key]
+    else:
+        pconfig = None
 
     parser = argparse.ArgumentParser(
         description='Remove stalled runs from database',
@@ -38,7 +40,7 @@ if __name__ == '__main__':
         raise Exception('No database file defined or found in defaults')
     
     connection = None
-    connection = lite.connect(database)
+    connection = lite.connect(db)
     with connection:
         cursor = connection.cursor()
         # Check if "currently running" in note, if it is, we do want to rerun
@@ -47,23 +49,25 @@ if __name__ == '__main__':
         lines = cursor.fetchall()
         for line in lines:
             id1, note1, eventid, ver = line
-            if 'Currently running...' in note1:
+            if 'Currently running' in note1:
                 # Delete it from the table
                 cursor.execute("DELETE FROM shakemap WHERE id = ?", (id1,))
-                # Delete the version directory, if it exists
-                verdirs = glob.glob(os.path.join(
-                    config['output_filepath'], '%s*' % eventid,
-                    'version.%03i' % ver))
-                if len(verdirs) > 0:
-                    for verd in verdirs:
-                        shutil.rmtree(verd)
+                if pconfig is not None and ver is not None:
+                    # Delete the version directory, if it exists
+                    verdirs = glob.glob(os.path.join(
+                        pconfig['output_filepath'], '%s*' % eventid,
+                        'version.%03i' % ver))
+                    if len(verdirs) > 0:
+                        for verd in verdirs:
+                            shutil.rmtree(verd)
 
     # Delete any empty output directories (might have been left from failed
     # runs)
-    for entry in os.scandir(config['output_filepath']):
-        if entry.is_dir():
-            files = glob.glob(os.path.join(entry.path, '*'))
-            if len(files) == 0:
-                shutil.rmtree(entry.path)
+    if pconfig is not None:
+        for entry in os.scandir(pconfig['output_filepath']):
+            if entry.is_dir():
+                files = glob.glob(os.path.join(entry.path, '*'))
+                if len(files) == 0:
+                    shutil.rmtree(entry.path)
 
 

--- a/bin/cleandb
+++ b/bin/cleandb
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# stdlib imports
+import argparse
+from configobj import ConfigObj
+import os
+import sqlite3 as lite
+
+
+
+if __name__ == '__main__':
+    """
+    Manually remove any "Currently running..." entries from the database
+    """
+    # See if there is a default path file, load in if there is and
+    # replace any nones
+    defaults = os.path.join(os.path.expanduser('~'), '.gfail_defaults')
+    dbfile = None
+    alerttype = 'value'
+
+    if os.path.exists(defaults):
+        D = ConfigObj(defaults)
+        for key in D:
+            if key == 'dbfile':
+                dbfile = D[key]
+
+    parser = argparse.ArgumentParser(
+        description='Remove stalled runs from database',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-d', '--database', metavar='database', nargs='?', default=dbfile,
+        type=str, help=('Location of database'))
+
+    pargs = parser.parse_args()
+    db = pargs.database
+    if db is None:
+        raise Exception('No database file defined or found in defaults')
+    
+    connection = None
+    connection = lite.connect(database)
+    with connection:
+        cursor = connection.cursor()
+        # Check if "currently running" in note, if it is, we do want to rerun
+        # because it didn't finish
+        cursor.execute("SELECT id, note, eventcode, version FROM shakemap")
+        lines = cursor.fetchall()
+        for line in lines:
+            id1, note1, eventid, ver = line
+            if 'Currently running...' in note1:
+                # Delete it from the table
+                cursor.execute("DELETE FROM shakemap WHERE id = ?", (id1,))
+                # Delete the version directory, if it exists
+                verdirs = glob.glob(os.path.join(
+                    config['output_filepath'], '%s*' % eventid,
+                    'version.%03i' % ver))
+                if len(verdirs) > 0:
+                    for verd in verdirs:
+                        shutil.rmtree(verd)
+
+    # Delete any empty output directories (might have been left from failed
+    # runs)
+    for entry in os.scandir(config['output_filepath']):
+        if entry.is_dir():
+            files = glob.glob(os.path.join(entry.path, '*'))
+            if len(files) == 0:
+                shutil.rmtree(entry.path)
+
+

--- a/bin/cleandb
+++ b/bin/cleandb
@@ -7,6 +7,7 @@ from configobj import ConfigObj
 import os
 import sqlite3 as lite
 import glob
+import shutil
 
 
 

--- a/bin/viewdb
+++ b/bin/viewdb
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     Code for easily getting information from the database of all ground failure
     events that have been run
 
-    If run with no arguments, it will just print a summary of the database
+    If run with no arguments, it will just print any currently running events
 
     If .gfail_defaults defines the database file, it does not need to be
     defined with -db flag.
@@ -152,8 +152,8 @@ if __name__ == '__main__':
         '--color', action='store_true',
         help='report alert colors instead of values on database printouts')
     parser.add_argument(
-        '-s', '--printsummary', action='store_false',
-        help='Suppress printing of summary')
+        '-s', '--printsummary', action='store_true',
+        help='Print summary')
     parser.add_argument(
         '--summaryplotfile', nargs='?', type=str, metavar='file_extension',
         help='Save summaryplot to this location (include extension)',

--- a/gfail/utilities.py
+++ b/gfail/utilities.py
@@ -636,6 +636,12 @@ def view_database(database, starttime=None, endtime=None,
     import warnings
     warnings.filterwarnings("ignore")
 
+    formatters = {"time": "{:%Y-%m-%d}".format,
+                  "shakemap_version": "{:.0f}".format,
+                  "version": "{:.0f}".format,
+                  "starttime": "{:%Y-%m-%d %H:%M}".format,
+                  "endtime": "{:%Y-%m-%d %H:%M}".format}
+
     criteria = dict(locals())
     # Define alert bins for later use
     hazbinLS = dict(green=[0., 1], yellow=[1., 10.], orange=[10., 100.],
@@ -654,6 +660,21 @@ def view_database(database, starttime=None, endtime=None,
 
     # Read in entire shakemap table, do selection using pandas
     df = pd.read_sql_query("SELECT * FROM shakemap", connection)
+
+    # Print currently running info to screen
+    print('-------------------------------------------------')
+    curt = df.loc[df['note'].str.contains('Currently running')]
+    if len(curt) > 0:
+        ccols = ['eventcode', 'time', 'shakemap_version', 'note', 'starttime']
+        ccols2 = ['eventcode', 'time', 'shake_v', 'note', 'startrun']
+        print('Currently running - %d runs' % len(curt))
+        print('-------------------------------------------------')
+        print(curt.to_string(columns=ccols, index=False,
+              justify='left', header=ccols2,
+              formatters=formatters))
+    else:
+        print('No events currently running')
+        print('-------------------------------------------------')
 
     okcols = list(df.keys())
 
@@ -922,11 +943,6 @@ def view_database(database, starttime=None, endtime=None,
         else:
             raise Exception('Cannot save csv file to %s' % csvfile)
 
-    formatters = {"time": "{:%Y-%m-%d}".format,
-                  "shakemap_version": "{:.0f}".format,
-                  "version": "{:.0f}".format,
-                  "starttime": "{:%Y-%m-%d %H:%M}".format,
-                  "endtime": "{:%Y-%m-%d %H:%M}".format}
     # Print to screen
     if stats['nsuccess'] > 0 and printsuccess:
         print('Successful - %d runs' % stats['nsuccess'])

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='groundfailure',
           'bin/create_info',
           'bin/create_png',
           'bin/gfail_transfer',
-          'bin/viewdb'
+          'bin/viewdb',
+          'bin/cleandb'
       ],
       )


### PR DESCRIPTION
Includes Eric's addition of code to retry the download a few times if it fails
then added a cleanup option to callgf that can be run as a cron job every so often that will rerun any events that didn't download the ShakeMap, rerun events that occurred >2 days ago and need warnings removed, and will remove any stalled runs in the database. Called like callgf -c
