### PR TITLE
Removed pending alerts option for real time

### DIFF
--- a/bin/callgf
+++ b/bin/callgf
@@ -1301,7 +1301,7 @@ def main(args, config, exitafter=True):
 
     logging.info("Running process_shakemap")
 
-    if str(args.event) != "unset":
+    if str(args.event) != "unset":  # Manual run
         # For manual run, event is set (default is 'unset')
         # download the shakemap to a temporary directory
         try:
@@ -1358,10 +1358,10 @@ def main(args, config, exitafter=True):
             shutil.rmtree(tdir)
     else:
         # Called by pdl, do not process if pending
-        if args.property_alertlevel == "pending":
+        if str(args.property_alertlevel) == "pending":
             logging.info("PAGER alert is pending, exiting.")
             sys.exit(0)
-        if args.type == "losspager":
+        if str(args.type) == "losspager":
             # Check if stopfile exists before proceeding
             isstopped(args, config)
             process_shakemap(args, config)

--- a/gfail/webpage.py
+++ b/gfail/webpage.py
@@ -497,16 +497,16 @@ def hazdev(
         pngfiles = create_png(outfolder, lsmodels, lqmodels)
         filenames.append(pngfiles)
 
-    # If PAGER alert is pending, overwrite our alerts
-    if pager_alert == "pending":
-        for ls in lsmodels:
-            ls["alert"] = "pending"
-            ls["hazard_alert"]["color"] = "pending"
-            ls["population_alert"]["color"] = "pending"
-        for lq in lqmodels:
-            lq["alert"] = "pending"
-            lq["hazard_alert"]["color"] = "pending"
-            lq["population_alert"]["color"] = "pending"
+    # # If PAGER alert is pending, overwrite our alerts
+    # if pager_alert == "pending":
+    #     for ls in lsmodels:
+    #         ls["alert"] = "pending"
+    #         ls["hazard_alert"]["color"] = "pending"
+    #         ls["population_alert"]["color"] = "pending"
+    #     for lq in lqmodels:
+    #         lq["alert"] = "pending"
+    #         lq["hazard_alert"]["color"] = "pending"
+    #         lq["population_alert"]["color"] = "pending"
 
     # Create info.json
     infojson = create_info(


### PR DESCRIPTION
When PAGER had a 'pending' status, GF was not supposed to run but an inconsistency in the interpretation of namespace may have allowed it to run occassionally anyway. FIxed that possible source of inconsistency. I also commented out the lines that make the alert levels for ground failure 'pending' if PAGER was 'pending' because webpages have no logic for visualization in those cases so it looks like an error. Pending PAGER events should still run and post if run manually. 